### PR TITLE
Add VHDL module for 100-bit addition

### DIFF
--- a/add100bits.vhd
+++ b/add100bits.vhd
@@ -1,0 +1,25 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity add100bits is
+    port (
+        a    : in  std_logic_vector(99 downto 0);
+        b    : in  std_logic_vector(99 downto 0);
+        sum  : out std_logic_vector(100 downto 0)
+    );
+end entity add100bits;
+
+architecture rtl of add100bits is
+begin
+    process (a, b)
+        variable unsigned_a : unsigned(a'range);
+        variable unsigned_b : unsigned(b'range);
+        variable result     : unsigned(sum'range);
+    begin
+        unsigned_a := unsigned(a);
+        unsigned_b := unsigned(b);
+        result     := resize(unsigned_a, sum'length) + resize(unsigned_b, sum'length);
+        sum        <= std_logic_vector(result);
+    end process;
+end architecture rtl;


### PR DESCRIPTION
## Summary
- add a reusable VHDL component that sums two 100-bit vectors
- ensure the output width accommodates the carry by providing a 101-bit result port

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d5072f4e24832b90f7cf9d6377de5c